### PR TITLE
add rate limits example from Gustavo

### DIFF
--- a/docs/api-rate-limits.md
+++ b/docs/api-rate-limits.md
@@ -1,39 +1,47 @@
-# Rate limits per environment
+# Rate limits
 
-Most Amadeus for Developers Self-Service APIs have [rate limits](https://developers.amadeus.com/self-service/apis-docs/guides/rate-limits-745) in place to protect against abuse by third-parties. The rate limits for each environment are detailed in the following table:
+## Rate limits per API
+[Amadeus Self-Service APIs](https://developers.amadeus.com/self-service) have two types of **rate limits** in place to protect against abuse by third parties.
+
+### Artificial Intelligence and Partners' APIs 
+
+Artificial intelligence APIs and APIs from Amadeus partners' are currently following the rate limits below. 
+
+<center>
+
+| Test and Production                   |
+|---------------------------------------|
+| 20 transactions per second, per user |
+| No more than 1 request every 50ms   |
+
+</center>
+
+| API Category             | API Sub Category        | API name                                                                                                                          |
+|--------------------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| Covid-19 & Travel Safety | Covid-19                | [Travel Restrictions](https://developers.amadeus.com/self-service/category/destination-content/api-doc/travel-restrictions)       |
+| Covid-19 & Travel Safety | Location Risk           | [ Safe Place ]( https://developers.amadeus.com/self-service/category/destination-content/api-doc/safe-place )                     |
+| Air                      | Artificial Intelligence | [ Airport On-time Performance ]( https://developers.amadeus.com/self-service/category/air/api-doc/airport-on-time-performance )   |
+| Air                      | Artificial Intelligence | [ Flight Price Analysis  ]( https://developers.amadeus.com/self-service/category/air/api-doc/flight-price-analysis )              |
+| Air                      | Artificial Intelligence | [ Flight Choice Prediction ]( https://developers.amadeus.com/self-service/category/air/api-doc/flight-choice-prediction )         |
+| Air                      | Artificial Intelligence | [ Flight Delay Prediction ]( https://developers.amadeus.com/self-service/category/air/api-doc/flight-delay-prediction )           |
+| Destination Content      | Location                | [ Points of Interest ]( https://developers.amadeus.com/self-service/category/destination-content/api-doc/points-of-interest )     |
+| Destination Content      | Location                | [ Tours and Activities ]( https://developers.amadeus.com/self-service/category/destination-content/api-doc/tours-and-activities ) |
+| Destination Content      | Travel Insight          | [ Location Score ]( https://developers.amadeus.com/self-service/category/destination-content/api-doc/location-score )             |
+
+
+
+### The other APIs
+
+**The rest of Self-Service APIs** apart from Artificial intelligence and Partners' APIs are below rate limits **per environment**.
+
+<center>
 
 | **Test** | **Production** |
 | :--- | :--- |
 | 10 transactions per second, per user | 40 transactions per second, per user  |
-| No more than 1 request every 100ms. | |
+| No more than 1 request every 100ms | |
 
-The following APIs are currently limited to **20 transactions per second** and **no more than 1 request every 50ms**:
+</center>
 
-
-## Air
-
-[Airport On-time Performance](https://developers.amadeus.com/self-service/category/air/api-doc/airport-on-time-performance)
-
-[Flight Price Analysis ](https://developers.amadeus.com/self-service/category/air/api-doc/flight-price-analysis)
-
-[Flight Choice Prediction](https://developers.amadeus.com/self-service/category/air/api-doc/flight-choice-prediction)
-
-[Flight Delay Prediction](https://developers.amadeus.com/self-service/category/air/api-doc/flight-delay-prediction)
-
-## Destination Content
-
-[Safe Place](https://developers.amadeus.com/self-service/category/destination-content/api-doc/safe-place)
-
-[Travel Restrictions](https://developers.amadeus.com/self-service/category/destination-content/api-doc/travel-restrictions)
-
-[Points of Interest](https://developers.amadeus.com/self-service/category/destination-content/api-doc/points-of-interest)
-
-[Location Score](https://developers.amadeus.com/self-service/category/destination-content/api-doc/location-score)
-
-[Tours and Activities](https://developers.amadeus.com/self-service/category/destination-content/api-doc/tours-and-activities)
-
-## Trip
-
-[Trip Purpose Prediction](https://developers.amadeus.com/self-service/category/trip/api-doc/trip-purpose-prediction)
-
-[Travel Recommendations](https://developers.amadeus.com/self-service/category/trip/api-doc/travel-recommendations)
+## Rate limits Examples 
+To manage the rate limits in APIs, we have mainly two options, use an external library or build a request queue from scratch. The choice depends on your resources and requisites. There are some great open-source ones available for the main programming languages. You can find [Rate limit examples](https://github.com/amadeus4dev-examples/APIRateLimits){:target="\_blank"} in Node, Python and Java using the respective [Amadeus SDK](https://amadeus4dev.github.io/developer-guides/programming/).

--- a/docs/programming/java.md
+++ b/docs/programming/java.md
@@ -150,3 +150,7 @@ SDK and discover new ways to use it.
 You can also check the video tutorial on how to get started with the Java SDK.
 
 ![type:video](https://www.youtube.com/embed/qCBj_mDkDjc)
+
+## Managing Amadeus API rate limits using the Java SDK
+
+[Amadeus Self-Service APIs](https://developers.amadeus.com/self-service) have [rate limits](https://amadeus4dev.github.io/developer-guides/api-rate-limits/) in place to protect against abuse by third parties. You can find Rate limit example in Java using the Amadeus Java SDK [here](https://github.com/amadeus4dev-examples/APIRateLimits/tree/master/Java){:target="\_blank"}. 

--- a/docs/programming/node.md
+++ b/docs/programming/node.md
@@ -144,3 +144,7 @@ If a page is not available, the response will resolve to `null`.
 You can also check the video tutorial on how to get started with the Node SDK.
 
 ![type:video](https://www.youtube.com/embed/rfkgJLKlI4s)
+
+## Managing Amadeus API rate limits using the Node SDK
+
+[Amadeus Self-Service APIs](https://developers.amadeus.com/self-service) have [rate limits](https://amadeus4dev.github.io/developer-guides/api-rate-limits/) in place to protect against abuse by third parties. You can find Rate limit example in Node using the Amadeus Node SDK [here](https://github.com/amadeus4dev-examples/APIRateLimits){:target="\_blank"}. 

--- a/docs/programming/python.md
+++ b/docs/programming/python.md
@@ -116,6 +116,10 @@ You can also check the video tutorial on how to get started with the Python SDK.
 
 ![type:video](https://www.youtube.com/embed/R8LolxJTzQk)
 
+### Managing Amadeus API rate limits using the Python SDK
+
+[Amadeus Self-Service APIs](https://developers.amadeus.com/self-service) have [rate limits](https://amadeus4dev.github.io/developer-guides/api-rate-limits/) in place to protect against abuse by third parties. You can find Rate limit example in Python using the Amadeus Python SDK [here](https://github.com/amadeus4dev-examples/APIRateLimits/tree/master/Python){:target="\_blank"}. 
+
 ## Python Async API calls
 
 In a synchronous program, each step is completed before moving on to the next one. However, an asynchronous program may not wait for each step to be completed. Asynchronous functions can pause and allow other functions to run while waiting for a result. This enables concurrent execution and gives the feeling of working on multiple tasks at the same time.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ theme:
 
 markdown_extensions:
   - admonition
+  - attr_list
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.snippets:


### PR DESCRIPTION
add rate limit examples & explanation in 4 pages
- rate limits
- python 
- node
- Java

and add `attr_list` markdown extension to enable {:target="\_blank"} 