### PR TITLE
Replace external links with internal

### DIFF
--- a/docs/api-rate-limits.md
+++ b/docs/api-rate-limits.md
@@ -38,4 +38,10 @@ Artificial intelligence APIs and APIs from Amadeus partners' are currently follo
 | No more than 1 request every 100ms | |
 
 ## Rate limits Examples 
-To manage the rate limits in APIs, we have mainly two options, use an external library or build a request queue from scratch. The choice depends on your resources and requisites. There are some great open-source ones available for the main programming languages. You can find [Rate limit examples](https://github.com/amadeus4dev-examples/APIRateLimits){:target="\_blank"} in Node, Python and Java using the respective [Amadeus SDK](https://amadeus4dev.github.io/developer-guides/programming/).
+To manage the rate limits in APIs, there are mainly two options: 
+- Use an external library
+- Build a request queue from scratch
+
+The right choice depends on your resources and requisites. 
+
+Check out the [rate limits examples](https://github.com/amadeus4dev-examples/APIRateLimits){:target="\_blank"} in Node, Python and Java using the respective [Amadeus SDKs](/docs/developer-tools/).

--- a/docs/developer-tools/java.md
+++ b/docs/developer-tools/java.md
@@ -141,8 +141,7 @@ The method `amadeus.shopping.flightDestinations.get()` will return an Array with
 System.out.println(flightDestinations[0]);
 ```
 
-Now that you've tried out this example and know
-how to use the objects, you can review the [Javadocs](https://amadeus4dev.github.io/amadeus-java/){:target="\_blank"} in this
+Now that you've tried out this example and know how to use the objects, you can review the [Javadocs](https://amadeus4dev.github.io/amadeus-java/){:target="\_blank"} in this
 SDK and discover new ways to use it.
 
 ### Video Tutorial
@@ -153,4 +152,4 @@ You can also check the video tutorial on how to get started with the Java SDK.
 
 ### Managing API rate limits
 
-[Amadeus Self-Service APIs](https://developers.amadeus.com/self-service){:target="\_blank"} have [rate limits](https://amadeus4dev.github.io/developer-guides/api-rate-limits/){:target="\_blank"} in place to protect against abuse by third parties. You can find Rate limit example in Java using the Amadeus Java SDK [here](https://github.com/amadeus4dev-examples/APIRateLimits/tree/master/Java){:target="\_blank"}. 
+[Amadeus Self-Service APIs](https://developers.amadeus.com/self-service){:target="\_blank"} have [rate limits](/docs/api-rate-limits.md){:target="\_blank"} in place to protect against abuse by third parties. You can find Rate limit example in Java using the Amadeus Java SDK [here](https://github.com/amadeus4dev-examples/APIRateLimits/tree/master/Java){:target="\_blank"}. 

--- a/docs/developer-tools/mock-server.md
+++ b/docs/developer-tools/mock-server.md
@@ -13,7 +13,7 @@ Let's now check step-by-step to create a mock server.
 
 ### 1. Save a request and response example
 
-For the sake of the tutorial we will show you how to create a mock server for the [Travel Recommendations API](https://developers.amadeus.com/self-service/category/trip/api-doc/travel-recommendations). We will make one request to the Amadeus API and then we will mock the request and response. To learn how to make an API call with Postman, please check this step-by-step [guide](https://amadeus4dev.github.io/developer-guides/developer-tools/postman/).
+For the sake of the tutorial we will show you how to create a mock server for the [Travel Recommendations API](https://developers.amadeus.com/self-service/category/trip/api-doc/travel-recommendations). We will make one request to the Amadeus API and then we will mock the request and response. To learn how to make an API call with Postman, please check this step-by-step [guide](/docs/developer-tools/postman.md).
 
 Open your Postman application and generate your Amadeus `access token` as described in the guide above. Then go to **Amadeus for Developers > Trip > Artificial Intelligenge > GET Travel Recommendations**  and make an API call.
 

--- a/docs/developer-tools/node.md
+++ b/docs/developer-tools/node.md
@@ -149,4 +149,4 @@ You can also check the video tutorial on how to get started with the Node SDK.
 
 ### Managing API rate limits
 
-[Amadeus Self-Service APIs](https://developers.amadeus.com/self-service){:target="\_blank"} have [rate limits](https://amadeus4dev.github.io/developer-guides/api-rate-limits/){:target="\_blank"} in place to protect against abuse by third parties. You can find Rate limit example in Node using the Amadeus Node SDK [here](https://github.com/amadeus4dev-examples/APIRateLimits){:target="\_blank"}. 
+[Amadeus Self-Service APIs](https://developers.amadeus.com/self-service){:target="\_blank"} have [rate limits](/docs/api-rate-limits.md){:target="\_blank"} in place to protect against abuse by third parties. You can find Rate limit example in Node using the Amadeus Node SDK [here](https://github.com/amadeus4dev-examples/APIRateLimits){:target="\_blank"}. 

--- a/docs/developer-tools/python.md
+++ b/docs/developer-tools/python.md
@@ -118,7 +118,7 @@ You can also check the video tutorial on how to get started with the Python SDK.
 
 ### Managing API rate limits
 
-[Amadeus Self-Service APIs](https://developers.amadeus.com/self-service){:target="\_blank"} have [rate limits](https://amadeus4dev.github.io/developer-guides/api-rate-limits/){:target="\_blank"} in place to protect against abuse by third parties. You can find Rate limit example in Python using the Amadeus Python SDK [here](https://github.com/amadeus4dev-examples/APIRateLimits/tree/master/Python){:target="\_blank"}. 
+[Amadeus Self-Service APIs](https://developers.amadeus.com/self-service){:target="\_blank"} have [rate limits](/docs/api-rate-limits.md){:target="\_blank"} in place to protect against abuse by third parties. You can find Rate limit example in Python using the Amadeus Python SDK [here](https://github.com/amadeus4dev-examples/APIRateLimits/tree/master/Python){:target="\_blank"}. 
 
 ## Python Async API calls
 
@@ -219,7 +219,7 @@ asyncio.run(main())
 
 In this tutorial, we'll guide you through the process of making your first API calls using the OpenAPI Generator in Python. To begin, you'll need to retrieve the specification files from the GitHub [repository](https://github.com/amadeus4dev/amadeus-open-api-specification){:target="\_blank"}. In this example, you will use the `Authorization_v1_swagger_specification.yaml` and `FlightOffersSearch_v2_swagger_specification.yaml` files.
 
-Before getting started make sure you check out how to [generate client libraries](https://amadeus4dev.github.io/developer-guides/developer-tools/openapi-generator/#step-1-setting-up-the-openapi-generator){:target="\_blank"} with the OpenAPI Generator.
+Before getting started make sure you check out how to [generate client libraries](/docs/developer-tools/openapi-generator.md){:target="\_blank"} with the OpenAPI Generator.
 
 ### Call the Authorization endpoint
 
@@ -267,7 +267,7 @@ print(api_response.body['access_token'])
 
 The code uses the library we have generated to get an OAuth2 access token. With the `o_auth2_access_token_api.OAuth2AccessTokenApi()` we are able to call the `oauth2_token()` method.
 
-The body of the request is being created by passing the `grant_type`, `client_id` and `client_secret` to the `oauth2_token()` method. If you want to know more about how to get the access token check the [authorization guide](https://amadeus4dev.github.io/developer-guides/API-Keys/authorization/?h=authori). 
+The body of the request is being created by passing the `grant_type`, `client_id` and `client_secret` to the `oauth2_token()` method. If you want to know more about how to get the access token check the [authorization guide](/docs/API-Keys/authorization.md). 
 
 ### Call the Flight Offers Search API
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -83,11 +83,11 @@ If you need to increase the number of monthly API calls, please consider moving 
 
 ### How do I access the Self-Service APIs documentation?
 
-Check our [Amadeus for Developers docs portal](https://amadeus4dev.github.io/developer-guides/) for links to interactive reference documentation for each API and helpful guides covering topics such as authorization, pagination and common errors. On the [Amadeus for Developers GitHub page](https://github.com/amadeus4dev/){:target="\_blank"}, you can also find code samples and SDKs.
+Check our [Amadeus for Developers docs portal](/docs/index.md) for links to interactive reference documentation for each API and helpful guides covering topics such as authorization, pagination and common errors. On the [Amadeus for Developers GitHub page](https://github.com/amadeus4dev/){:target="\_blank"}, you can also find code samples and SDKs.
 
 ### Do you provide SDKs?
 
-Yes! On the [Amadeus for Developers GitHub page](https://github.com/amadeus4dev/){:target="\_blank"} you can find open-source SDKs in various languages. Alternatively, you can use [OpenAPI Generator](https://amadeus4dev.github.io/developer-guides/sdks/openapi-generator/){:target="\_blank"} to create an SDK from our [OpenAPI files](https://github.com/amadeus4dev/amadeus-open-api-specification){:target="\_blank"}.
+Yes! On the [Amadeus for Developers GitHub page](https://github.com/amadeus4dev/){:target="\_blank"} you can find open-source SDKs in various languages. Alternatively, you can use [OpenAPI Generator](/docs/developer-tools/openapi-generator.md){:target="\_blank"} to create an SDK from our [OpenAPI files](https://github.com/amadeus4dev/amadeus-open-api-specification){:target="\_blank"}.
 
 ### Where can I see code examples for Amadeus Self-Service APIs?
 
@@ -100,7 +100,7 @@ On the [Get Started with Self-Service APIs](https://developers.amadeus.com/get-s
 
 ### How do I move Self-Service APIs from test to production?
 
-To launch your application to production, please follow the steps described in our [Moving to production](https://amadeus4dev.github.io/developer-guides/API-Keys/moving-to-production/){:target="\_blank"} guide.
+To launch your application to production, please follow the steps described in our [Moving to production](/docs/API-Keys/moving-to-production.md){:target="\_blank"} guide.
 
 You will be asked to sign a contract and provide billing information before receiving your new API key. When you move to production, you will maintain the same free monthly request quota you enjoyed in test. When you reach your monthly threshold, you will be billed for the additional API calls you make at the rates shown on our [Pricing page](https://developers.amadeus.com/pricing){:target="\_blank"}.
 
@@ -131,7 +131,7 @@ We do not return data on American Airlines, Low cost carriers, and, in some mark
 
 ### What is an API key?
 
-An API key is a unique reference number which identifies your application to Amadeus. The API key is part of the authorization process and must be sent with each API request. If you have multiple applications using Amadeus APIs, each application must have its own API key. For more details, check our [Authorization guide](https://amadeus4dev.github.io/developer-guides/API-Keys/authorization/).
+An API key is a unique reference number which identifies your application to Amadeus. The API key is part of the authorization process and must be sent with each API request. If you have multiple applications using Amadeus APIs, each application must have its own API key. For more details, check our [Authorization guide](/docs/API-Keys/authorization.md).
 
 Your API keys are also used to track usage. To avoid unwanted charges, please do no share or post them in public repositories. For more information, see this [article on best practices for secure API key storage](https://developers.amadeus.com/blog/best-practices-api-key-storage){:target="\_blank"}.
 
@@ -210,7 +210,7 @@ If you wish to keep using the APIs, you can either move your app to production a
 
 ### Is the data returned in the Self-Service test environment accurate?
 
-The information returned in test environment is from [limited data collections](https://amadeus4dev.github.io/developer-guides/test-data/){:target="\_blank"}. This is done as a security measure to protect our data and our customers. When you move to production, you will get access to complete and live data.
+The information returned in test environment is from [limited data collections](/docs/test-data.md){:target="\_blank"}. This is done as a security measure to protect our data and our customers. When you move to production, you will get access to complete and live data.
 
 ## Flight Inspiration Search
 

--- a/docs/resources/covid-19.md
+++ b/docs/resources/covid-19.md
@@ -117,7 +117,7 @@ curl https://test.api.amadeus.com/v1/safety/safety-rated-locations/Q930400878
 Let's highlight some information that you'll get from both Travel Restrictions API and Safe Place API. 
 
 !!! Warning
-    Don't forget that Amadeus for Developers provides a `Test Environment` with [limited data collections](https://amadeus4dev.github.io/developer-guides/guides/api-data-collection/){:target="\_blank"}. 
+    Don't forget that Amadeus for Developers provides a `Test Environment` with [limited data collections](/docs/test-data.md){:target="\_blank"}. 
 
 !!! information
    - the data for Travel Restrictions API comes from [Riskline](https://riskline.com/){:target="\_blank"} and it has been sourced from local governments and media. The quantity of information provided may vary from country to country. 

--- a/docs/resources/flights.md
+++ b/docs/resources/flights.md
@@ -401,7 +401,7 @@ With the parameter `excludedAirlineCodes` you can ignore specific airlines. For 
 
 #### Interactive code examples
 
-Check out this [interactive code example](https://amadeus4dev.github.io/developer-guides/examples/live-examples/#flight-search-form) which provides a flight search form to help you build your app. You can easily customize it and use the Flight Offers Search API to get the cheapest flight offers.
+Check out this [interactive code example](/docs/examples/live-examples.md#flight-search-form) which provides a flight search form to help you build your app. You can easily customize it and use the Flight Offers Search API to get the cheapest flight offers.
 
 ### Search for the best flight option
 

--- a/docs/resources/hotels.md
+++ b/docs/resources/hotels.md
@@ -235,9 +235,9 @@ GET https://test.api.amadeus.com/v1/reference-data/locations/hotels/by-hotels?ho
 
 ### Interactive code examples 
 
-Check out this [interactive code example](https://amadeus4dev.github.io/developer-guides/examples/live-examples/#hotel-search-form) which provides a hotel search form to help you build your app. You can easily customize it and use the Hotel Search API to get the cheapest flight offers.
+Check out this [interactive code example](/docs/examples/live-examples.md#hotel-search-form) which provides a hotel search form to help you build your app. You can easily customize it and use the Hotel Search API to get the cheapest flight offers.
 
-### Autocomplete Hotel Names 
+### Autocomplete Hotel Names
 
 Your application can also display a list of suggested hotel names based on keywords used in the search query. 
 

--- a/docs/test-data.md
+++ b/docs/test-data.md
@@ -1,6 +1,6 @@
 # Free test data collection of Self-Service APIs
 
-Amadeus for Developers offers a `test environment` with free limited data. This allows developers to build and test their applications before deploying them to production. To access real-time data, you will need to move to the [production environment](https://amadeus4dev.github.io/developer-guides/API-Keys/moving-to-production/){:target="\_blank"}.
+Amadeus for Developers offers a `test environment` with free limited data. This allows developers to build and test their applications before deploying them to production. To access real-time data, you will need to move to the [production environment](/docs/API-Keys/moving-to-production.md){:target="\_blank"}.
 
 !!! warning
     It is important to note that the test environment protects our customers and data and it's exclusively intended for development purposes.
@@ -14,7 +14,7 @@ The test environment has the following differences with the production:
 | **Test**  | Free monthly quota | 10 TPS | Limited, cached | test.api.amadeus.com
 | **Production**  | Unlimited | 40 TPS | Unlimited, real-time | api.amadeus.com
 
-Check out the [rate limits guide](https://amadeus4dev.github.io/developer-guides/api-rate-limits/){:target="\_blank"} and [pricing page](https://developers.amadeus.com/pricing){:target="\_blank"} if you want to get more information on the specific topics. In this tutorial you can learn how to build a [mock server](./developer-tools/mock-server.md){:target="\_blank"} in Postman to help you consume less of your free quota.
+Check out the [rate limits guide](/docs/api-rate-limits.md){:target="\_blank"} and [pricing page](https://developers.amadeus.com/pricing){:target="\_blank"} if you want to get more information on the specific topics. In this tutorial you can learn how to build a [mock server](./developer-tools/mock-server.md){:target="\_blank"} in Postman to help you consume less of your free quota.
 
 ### API usage
 


### PR DESCRIPTION
In our docs we have links pointing to one page from another, using the http links instead of the local ones:

For example, (https://amadeus4dev.github.io/developer-guides/developer-tools/postman/) instead of (/docs/api-rate-limits.md) when we want to refer the users to the rate limits page. 

This PR updates the links as well as minor text changes