### PR TITLE
Fix search bar (wip)

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -3,10 +3,7 @@
     -#}
     
 {% extends "base.html" %}
-    {% block redirection %}
-    <html lang="en">
-        <head>
-            <meta charset="utf-8">
+    {% block extrahead %}
             <script>
                 if (window.location.hostname === 'amadeus4dev.github.io') {
                     console.log(window.location.hostname);
@@ -17,6 +14,4 @@
                     <link rel="canonical" href="${redirectUrl}" />`);
                 }
             </script>
-        </head>
-    </html>
     {% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -3,7 +3,7 @@
     -#}
     
 {% extends "base.html" %}
-    {% block scripts %}
+    {% block redirection %}
     <html lang="en">
         <head>
             <meta charset="utf-8">


### PR DESCRIPTION
Changed the name of the block according to the available options in the [documentation](https://www.mkdocs.org/user-guide/customizing-your-theme/).

The block seems to be executed when I added locally a console.log. 

